### PR TITLE
It's better to use relative path...

### DIFF
--- a/jabbershd
+++ b/jabbershd
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require 'lib/boot'
+require "#{File.dirname(__FILE__)}/lib/boot"
 
 Daemons.run_proc File.basename(__FILE__) do
   JabberShell.new.run


### PR DESCRIPTION
I got the error:
cannot load such file -- lib/boot (LoadError)
